### PR TITLE
fixing issue with multiple packages in one dir

### DIFF
--- a/example/example_test.go
+++ b/example/example_test.go
@@ -1,9 +1,10 @@
-package scard_test
+package example
 
 import (
 	"fmt"
-	"github.com/ebfe/scard"
 	"os"
+
+	"github.com/ebfe/scard"
 )
 
 func die(err error) {


### PR DESCRIPTION
moves `scard_test` package --> `example` and renames package `example`